### PR TITLE
Run flake on all environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
   rev: v1.3.0
   hooks:
   - id: flake8
+    additional_dependencies: ["flake8-bugbear==18.2.0"]

--- a/elasticsearch_metrics/management/commands/sync_metrics.py
+++ b/elasticsearch_metrics/management/commands/sync_metrics.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,6 @@
 envlist =
     py27-django111
     py36-django{111,20}
-    lint
-
-[travis]
-python =
-    2.7: py27
-    ; Only lint in 3.6 environment
-    3.6: lint, py36
 
 ; Match the DJANGO envvar to the
 ; corresponding tox environment
@@ -23,12 +16,5 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
 commands=
+    pre-commit run --all-files --verbose
     pytest {posargs}
-
-; NOTE: pre-commit runs both black and flake8
-[testenv:lint]
-skip_install = true
-basepython = python3.6
-deps =
-    pre-commit
-commands = pre-commit run --all-files --verbose


### PR DESCRIPTION
Not sure why the lint environment isn't running on the Python3.6
builds, so for now just run flake in all environments.

close #7