### PR TITLE
Rename metric -> metrics

### DIFF
--- a/.konchrc
+++ b/.konchrc
@@ -29,7 +29,7 @@ def setup():
     # Set up django and add the default elasticsearch-py client and Metric to the context
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
     django.setup()
-    from elasticsearch_metrics.metric import Metric
+    from elasticsearch_metrics.metrics import Metric
     context["client"] = connections.get_connection()
     context["Metric"] = Metric
     konch.config({"context": context})

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A `Metric` is a subclass of [`elasticsearch_dsl.Document`](https://elasticsearch
 ```python
 # myapp/metrics.py
 
-from elasticsearch_metrics.metric import Metric
+from elasticsearch_metrics.metrics import Metric
 from elasticsearch_dsl import Integer
 
 class PageView(Metric):
@@ -128,7 +128,7 @@ class PageView(Metric):
 ## Abstract metrics
 
 ```python
-from elasticsearch_metrics.metric import Metric
+from elasticsearch_metrics.metrics import Metric
 from elasticsearch_dsl import Integer
 
 class MyBaseMetric(Metric):

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -63,7 +63,7 @@ class BaseMetric(object):
 
     .. code-block:: python
 
-        from elasticsearch_metrics import Metric
+        from elasticsearch_metrics.metrics import Metric
 
         class PageView(Metric):
             user_id = Integer()

--- a/tests/dummyapp/metrics.py
+++ b/tests/dummyapp/metrics.py
@@ -1,4 +1,4 @@
-from elasticsearch_metrics.metric import Metric
+from elasticsearch_metrics.metrics import Metric
 
 
 class DummyMetric(Metric):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,7 @@ import pytest
 import datetime as dt
 from django.conf import settings
 from django.utils import timezone
-from elasticsearch_metrics.metric import Metric
+from elasticsearch_metrics.metrics import Metric
 from elasticsearch_dsl import IndexTemplate, connections, Keyword, MetaField
 
 from elasticsearch_metrics.signals import pre_index_template_create


### PR DESCRIPTION
For consistency with, e.g. django.db.models, rest_framework.serializers