### PR TITLE
Add pre_save and post_save signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,12 @@ python manage.py clean_metrics myapp.PageView --older-than 45 --time-unit days
 
 Signals are located in the `elasticsearch_metrics.signals` module.
 
-* `pre_index_template_create(Metric, index_template)`: Sent before `PUT`ting a new index
+* `pre_index_template_create(Metric, index_template, using)`: Sent before `PUT`ting a new index
     template into Elasticsearch.
-
+* `pre_save(Metric, instance, using, index)`: Sent at the beginning of a
+    Metric's `save()` method.
+* `post_save(Metric, instance, using, index)`: Sent at the end of a
+    Metric's `save()` method.
 
 ## Caveats
 

--- a/elasticsearch_metrics/signals.py
+++ b/elasticsearch_metrics/signals.py
@@ -1,5 +1,10 @@
 from django.dispatch import Signal
 
+# TODO: Allow passing sender as string, a la ModelSignal?
+
 # Sent before index template is created in elastic search
-# TODO document in README
-pre_index_template_create = Signal(providing_args=["index_template"])
+pre_index_template_create = Signal(providing_args=["index_template", "using"])
+# Sent at the beginning of Metric's save()
+pre_save = Signal(providing_args=["instance", "using", "index"])
+# Like pre_save, but sent at the end of the save() method
+post_save = Signal(providing_args=["instance", "using", "index"])


### PR DESCRIPTION
Add `pre_save` and `post_save` signals.

Also, allow passing `using` to create_index_template,
  for consistency

close #21