### PR TITLE
Add registry of Metric classes

### DIFF
--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -53,7 +53,10 @@ class MetricMeta(IndexMeta):
 
         new_cls._template_name = template_name
         new_cls._template = template
-        registry.register(app_label, new_cls)
+        # Abstract base metrics can't be instantiated and don't appear in
+        # the list of metrics for an app.
+        if not abstract:
+            registry.register(app_label, new_cls)
         return new_cls
 
 

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -40,7 +40,7 @@ class Registry(object):
         metric exists with this name in the application. Raise ValueError if
         called with a single argument that doesn't contain exactly one dot.
         """
-        self.check_apps_ready()
+        apps.check_apps_ready()
 
         if metric_name is None:
             app_label, metric_name = app_label.split(".")
@@ -55,15 +55,14 @@ class Registry(object):
 
     def get_metrics(self, app_label=None):
         """Return list of registered metric classes, optionally filtered on an app_label."""
+        apps.check_apps_ready()
+
         app_labels = [app_label] if app_label else self.all_metrics.keys()
         result = []
         for app_label in app_labels:
             app_metrics = self._get_metrics_for_app(app_label=app_label)
             result.extend(list(app_metrics.values()))
         return result
-
-    def check_apps_ready(self):
-        return apps.check_apps_ready()
 
     def _get_metrics_for_app(self, app_label):
         if app_label not in self.all_metrics:

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -45,11 +45,7 @@ class Registry(object):
         if metric_name is None:
             app_label, metric_name = app_label.split(".")
 
-        if app_label not in self.all_metrics:
-            raise LookupError(
-                "No metrics found in app with label '{}'.".format(app_label)
-            )
-        app_metrics = self.all_metrics[app_label]
+        app_metrics = self._get_metrics_for_app(app_label=app_label)
         try:
             return app_metrics[metric_name.lower()]
         except KeyError:
@@ -59,21 +55,22 @@ class Registry(object):
 
     def get_metrics(self, app_label=None):
         """Return list of registered metric classes, optionally filtered on an app_label."""
-        if app_label:
-            if app_label not in self.all_metrics:
-                raise LookupError(
-                    "No metrics found in app with label '{}'.".format(app_label)
-                )
-            app_labels = [app_label]
-        else:
-            app_labels = self.all_metrics.keys()
+        app_labels = [app_label] if app_label else self.all_metrics.keys()
         result = []
         for app_label in app_labels:
-            result.extend(list(self.all_metrics[app_label].values()))
+            app_metrics = self._get_metrics_for_app(app_label=app_label)
+            result.extend(list(app_metrics.values()))
         return result
 
     def check_apps_ready(self):
         return apps.check_apps_ready()
+
+    def _get_metrics_for_app(self, app_label):
+        if app_label not in self.all_metrics:
+            raise LookupError(
+                "No metrics found in app with label '{}'.".format(app_label)
+            )
+        return self.all_metrics[app_label]
 
 
 registry = Registry()

--- a/elasticsearch_metrics/registry.py
+++ b/elasticsearch_metrics/registry.py
@@ -1,0 +1,79 @@
+from django.apps import apps
+from collections import defaultdict, OrderedDict
+
+
+class Registry(object):
+    """Registry that keeps track of Metric classes (similar to how
+    django.apps.registry.Apps keeps track of Model classes).
+    """
+
+    def __init__(self):
+        # Mapping of app labels => metric names => metric classes
+        # Every time a metric is imported, MetricMeta.__new__
+        # calls registry.register which creates
+        # an entry in all_metrics.
+        self.all_metrics = defaultdict(OrderedDict)
+
+    # similar to apps.register_model
+    def register(self, app_label, metric_cls):
+        """Add a Metric to the registry."""
+        app_metrics = self.all_metrics[app_label]
+        metric_name = metric_cls.__name__.lower()
+        if metric_name in app_metrics:
+            # Raise an error for conflicting metrics (same behavior as apps.register_model)
+            raise RuntimeError(
+                "Conflicting '{}' metrics in application '{}': {} and {}.".format(
+                    metric_name, app_label, app_metrics[metric_name], metric_cls
+                )
+            )
+        app_metrics[metric_name] = metric_cls
+
+    # similar to apps.get_model
+    def get_metric(self, app_label, metric_name=None):
+        """Return the metric matching the given app_label and model_name.
+
+        As a shortcut, app_label may be in the form <app_label>.<model_name>.
+
+        model_name is case-insensitive.
+
+        Raise LookupError if no application exists with this label, or no
+        metric exists with this name in the application. Raise ValueError if
+        called with a single argument that doesn't contain exactly one dot.
+        """
+        self.check_apps_ready()
+
+        if metric_name is None:
+            app_label, metric_name = app_label.split(".")
+
+        if app_label not in self.all_metrics:
+            raise LookupError(
+                "No metrics found in app with label '{}'.".format(app_label)
+            )
+        app_metrics = self.all_metrics[app_label]
+        try:
+            return app_metrics[metric_name.lower()]
+        except KeyError:
+            raise LookupError(
+                "App '{}' doesn't have a '{}' metric.".format(app_label, metric_name)
+            )
+
+    def get_metrics(self, app_label=None):
+        """Return list of registered metric classes, optionally filtered on an app_label."""
+        if app_label:
+            if app_label not in self.all_metrics:
+                raise LookupError(
+                    "No metrics found in app with label '{}'.".format(app_label)
+                )
+            app_labels = [app_label]
+        else:
+            app_labels = self.all_metrics.keys()
+        result = []
+        for app_label in app_labels:
+            result.extend(list(self.all_metrics[app_label].values()))
+        return result
+
+    def check_apps_ready(self):
+        return apps.check_apps_ready()
+
+
+registry = Registry()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -28,6 +28,7 @@ class PreprintView(Metric):
         settings = {"refresh_interval": "-1"}
 
     class Meta:
+        app_label = "dummyapp"
         template_name = "osf_metrics_preprintviews"
         template = "osf_metrics_preprintviews-*"
 
@@ -217,6 +218,7 @@ class TestIntegration:
     def test_source_may_be_enabled(self, client):
         class MyMetric(Metric):
             class Meta:
+                app_label = "dummyapp"
                 template_name = "mymetric"
                 template = "mymetric-*"
                 source = MetaField(enabled=True)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,55 @@
+import pytest
+
+from elasticsearch_metrics.metrics import Metric
+from elasticsearch_metrics.registry import registry
+from tests.dummyapp.metrics import DummyMetric
+
+
+class MetricWithAppLabel(Metric):
+    class Meta:
+        app_label = "dummyapp"
+
+
+def test_metric_in_app_is_in_registry():
+    assert "dummyapp" in registry.all_metrics
+    assert registry.all_metrics["dummyapp"]["dummymetric"] is DummyMetric
+
+
+def test_metric_with_explicit_label_set_is_in_regisry():
+    assert registry.all_metrics["dummyapp"]["metricwithapplabel"] is MetricWithAppLabel
+
+
+def test_conflicting_metric():
+    with pytest.raises(RuntimeError):
+
+        class DummyMetric(Metric):
+            class Meta:
+                app_label = "dummyapp"
+
+
+def test_get_metric():
+    assert registry.get_metric("dummyapp", "DummyMetric") is DummyMetric
+    assert registry.get_metric("dummyapp.DummyMetric") is DummyMetric
+
+    with pytest.raises(LookupError) as excinfo:
+        registry.get_metric("dummyapp", "DoesNotExist")
+    assert (
+        "App 'dummyapp' doesn't have a 'DoesNotExist' metric." in excinfo.value.args[0]
+    )
+
+    with pytest.raises(LookupError) as excinfo:
+        registry.get_metric("notanapp", "DummyMetric")
+    assert "No metrics found in app with label 'notanapp'." in excinfo.value.args[0]
+
+
+def test_get_metrics():
+    class AnotherMetric(Metric):
+        class Meta:
+            app_label = "anotherapp"
+
+    assert DummyMetric in registry.get_metrics()
+    assert DummyMetric in registry.get_metrics(app_label="dummyapp")
+    assert AnotherMetric not in registry.get_metrics(app_label="dummyapp")
+
+    with pytest.raises(LookupError):
+        registry.get_metrics("notanapp")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,7 @@ def test_metric_in_app_is_in_registry():
     assert registry.all_metrics["dummyapp"]["dummymetric"] is DummyMetric
 
 
-def test_metric_with_explicit_label_set_is_in_regisry():
+def test_metric_with_explicit_label_set_is_in_registry():
     assert registry.all_metrics["dummyapp"]["metricwithapplabel"] is MetricWithAppLabel
 
 
@@ -48,8 +48,23 @@ def test_get_metrics():
             app_label = "anotherapp"
 
     assert DummyMetric in registry.get_metrics()
+    assert AnotherMetric in registry.get_metrics()
     assert DummyMetric in registry.get_metrics(app_label="dummyapp")
     assert AnotherMetric not in registry.get_metrics(app_label="dummyapp")
 
-    with pytest.raises(LookupError):
+    with pytest.raises(LookupError) as excinfo:
         registry.get_metrics("notanapp")
+    assert "No metrics found in app with label 'notanapp'." in excinfo.value.args[0]
+
+
+def test_get_metrics_excludes_abstract_metrics():
+    class AbstractMetric(Metric):
+        class Meta:
+            abstract = True
+
+    class ConcreteMetric(AbstractMetric):
+        class Meta:
+            app_label = "anotherapp"
+
+    assert AbstractMetric not in registry.get_metrics()
+    assert ConcreteMetric in registry.get_metrics()


### PR DESCRIPTION
Similar to django.apps.apps, elasticsearch_metrics.registry.registry
keeps track of all declared Metric classes.

Whenever a new Metric class is declared, `MetricMeta.__new__` will call `registry.register` for the class.

Our mgmt commands will use this registry to create index templates.

close #24