### PR TITLE
Don't add Metric class to registry

### DIFF
--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -18,10 +18,11 @@ class MetricMeta(IndexMeta):
         module = attrs.get("__module__")
 
         new_cls = super(MetricMeta, mcls).__new__(mcls, name, bases, attrs)
-        parents = [b for b in bases if isinstance(b, MetricMeta)]
         # Also ensure initialization is only performed for subclasses of Metric
         # (excluding Metric class itself).
-        if not parents:
+        if not any(
+            b for b in bases if isinstance(b, MetricMeta) and b is not BaseMetric
+        ):
             return new_cls
 
         template_name = getattr(meta, "template_name", None)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -66,5 +66,6 @@ def test_get_metrics_excludes_abstract_metrics():
         class Meta:
             app_label = "anotherapp"
 
+    assert Metric not in registry.get_metrics()
     assert AbstractMetric not in registry.get_metrics()
     assert ConcreteMetric in registry.get_metrics()


### PR DESCRIPTION
This fixes the logic in MetricMeta so that `Metric` is considered the "top-level" class and therefore isn't added to the registry.