### PR TITLE
python manage.py sync_metrics

### DIFF
--- a/elasticsearch_metrics/management/commands/sync_metrics.py
+++ b/elasticsearch_metrics/management/commands/sync_metrics.py
@@ -1,12 +1,37 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+
+from elasticsearch_metrics.registry import registry
 
 
 class Command(BaseCommand):
     help = "Ensures index templates exist for all Metric classes."
 
     def add_arguments(self, parser):
-        pass
+        parser.add_argument(
+            "app_label",
+            nargs="?",
+            help="App label of an application to synchronize the state.",
+        )
+        # TODO: "using"
 
     def handle(self, *args, **options):
-        # TODO
+        if options["app_label"]:
+            if options["app_label"] not in registry.all_metrics:
+                raise CommandError(
+                    "No metrics found for app '{}'".format(options["app_label"])
+                )
+            app_labels = [options["app_label"]]
+        else:
+            app_labels = registry.all_metrics.keys()
+        for app_label in app_labels:
+            self.stdout.write("Syncing metrics for app '{}'".format(app_label))
+            metrics = registry.get_metrics(app_label=app_label)
+            for metric in metrics:
+                template_name = metric._template_name
+                template = metric._template
+                self.stdout.write(
+                    "  Syncing template {template_name} ({template})".format(**locals())
+                )
+                metric.create_index_template()
+
         self.stdout.write("Synchronized metrics.", self.style.SUCCESS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,19 @@ def _es_marker(request, client):
         teardown_es()
     else:
         yield
+
+
+@pytest.fixture()
+def run_mgmt_command(capsys):
+    """Function fixture that runs a python manage.py with arguments
+    and returns the stdout and stderr as a tuple.
+    """
+
+    def f(cmd_class, argv=None):
+        argv = argv or []
+        cmd = cmd_class()
+        cmd.run_from_argv(["manage.py"] + argv)
+        out, err = capsys.readouterr()
+        return out, err
+
+    return f

--- a/tests/test_management_commands/test_sync_metrics.py
+++ b/tests/test_management_commands/test_sync_metrics.py
@@ -1,14 +1,33 @@
 import pytest
+import mock
 from elasticsearch_metrics.management.commands.sync_metrics import Command
+from elasticsearch_metrics.metrics import Metric
+from elasticsearch_metrics.registry import registry
 
 
-def test_without_args(capsys):
-    cmd = Command()
-    cmd.run_from_argv(["manage.py", "sync_metrics"])
-    out, err = capsys.readouterr()
+@pytest.fixture()
+def mock_create_index_template():
+    patch = mock.patch("elasticsearch_metrics.metrics.Metric.create_index_template")
+    return patch.start()
+
+
+def test_without_args(run_mgmt_command, mock_create_index_template):
+    out, err = run_mgmt_command(Command, ["sync_metrics"])
+    assert mock_create_index_template.call_count == len(registry.get_metrics())
     assert "Synchronized metrics." in out
 
 
-@pytest.mark.xfail
-def test_synchronizes_all_metrics():
-    assert 0, "todo"
+def test_with_invalid_app(capsys, run_mgmt_command, mock_create_index_template):
+    with pytest.raises(SystemExit):
+        run_mgmt_command(Command, ["sync_metrics", "notanapp"])
+    out, err = capsys.readouterr()
+    assert "No metrics found for app 'notanapp'" in err
+
+
+def test_with_app_label(run_mgmt_command, mock_create_index_template):
+    class DummyMetric2(Metric):
+        class Meta:
+            app_label = "dummyapp2"
+
+    out, err = run_mgmt_command(Command, ["sync_metrics", "dummyapp2"])
+    assert mock_create_index_template.call_count == 1


### PR DESCRIPTION
Add `python manage.py sync_metrics` for creating ES index templates for each registered metric.

TODO:

- [x] Finish tests

Close #16 