### PR TITLE
Make fields importable from the metrics module and add Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ A `Metric` is a subclass of [`elasticsearch_dsl.Document`](https://elasticsearch
 ```python
 # myapp/metrics.py
 
-from elasticsearch_metrics.metrics import Metric
-from elasticsearch_dsl import Integer
+from elasticsearch_metrics import metrics
 
 
-class PageView(Metric):
-    user_id = Integer()
+class PageView(metrics.Metric):
+    user_id = metrics.Integer()
 ```
 
 Use the `sync_metrics` management command to ensure that the [index template](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html)
@@ -83,8 +82,8 @@ You can configure the index template settings by setting
 `Metric.Index.settings`.
 
 ```python
-class PageView(Metric):
-    user_id = Integer()
+class PageView(metrics.Metric):
+    user_id = metrics.Integer()
 
     class Index:
         settings = {"number_of_shards": 2, "refresh_interval": "5s"}
@@ -103,7 +102,7 @@ If you declare a `Metric` outside of an app, you will need to set
 
 
 ```python
-class PageView(Metric):
+class PageView(metrics.Metric):
     class Meta:
         app_label = "myapp"
 ```
@@ -111,8 +110,8 @@ class PageView(Metric):
 Alternatively, you can set `template_name` and/or `template` explicitly.
 
 ```python
-class PageView(Metric):
-    user_id = Integer()
+class PageView(metrics.Metric):
+    user_id = metrics.Integer()
 
     class Meta:
         template_name = "myapp_pviews"
@@ -122,12 +121,11 @@ class PageView(Metric):
 ## Abstract metrics
 
 ```python
-from elasticsearch_metrics.metrics import Metric
-from elasticsearch_dsl import Integer
+from elasticsearch_metrics import metrics
 
 
-class MyBaseMetric(Metric):
-    user_id = Integer()
+class MyBaseMetric(metrics.Metric):
+    user_id = metrics.Integer()
 
     class Meta:
         abstract = True
@@ -182,9 +180,9 @@ Signals are located in the `elasticsearch_metrics.signals` module.
     To enable `_source`, you can override it in `class Meta`.
 
 ```python
-class MyMetric(Metric):
+class MyMetric(metrics.Metric):
     class Meta:
-        source = MetaField(enabled=True)
+        source = metrics.MetaField(enabled=True)
 ```
 
 ## License

--- a/elasticsearch_metrics/field.py
+++ b/elasticsearch_metrics/field.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from elasticsearch_dsl import field as edsl_field
+
+__all__ = ["Date"]
+# Expose all fields from elasticsearch_dsl.field
+# We do this instead of 'from elasticsearch_dsl.field import *' because elasticsearch_metrics
+# has its own subclass of Date
+for each in (
+    field_name
+    for field_name in dir(edsl_field)
+    if field_name != "Date" and not field_name.startswith("_")
+):
+    field = getattr(edsl_field, each)
+    is_field_subclass = isinstance(field, type) and issubclass(field, edsl_field.Field)
+    if field is edsl_field.Field or is_field_subclass:
+        globals()[each] = field
+        field.__module__ = __name__
+        __all__.append(each)
+
+
+class Date(edsl_field.Date):
+    """Same as `elasticsearch_dsl.field.Date` except that this respects
+    the TIMEZONE Django setting.
+    """
+
+    def __init__(self, default_timezone=None, *args, **kwargs):
+        default_timezone = default_timezone or getattr(settings, "TIMEZONE", None)
+        super(Date, self).__init__(default_timezone=default_timezone, *args, **kwargs)

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -2,11 +2,15 @@ from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
 from django.utils.six import add_metaclass
-from elasticsearch_dsl import Document, Date
+from elasticsearch_dsl import Document
 from elasticsearch_dsl.document import IndexMeta, MetaField
 
 from elasticsearch_metrics.signals import pre_index_template_create, pre_save, post_save
 from elasticsearch_metrics.registry import registry
+
+# Fields should be imported from this module
+from elasticsearch_metrics.field import *  # noqa: F40
+from elasticsearch_metrics.field import Date
 
 DEFAULT_DATE_FORMAT = "%Y.%m.%d"
 
@@ -73,10 +77,10 @@ class BaseMetric(object):
 
     .. code-block:: python
 
-        from elasticsearch_metrics.metrics import Metric
+        from elasticsearch_metrics import metrics
 
-        class PageView(Metric):
-            user_id = Integer()
+        class PageView(metrics.Metric):
+            user_id = metrics.Integer()
 
             class Index:
                 settings = {

--- a/tests/dummyapp/metrics.py
+++ b/tests/dummyapp/metrics.py
@@ -1,15 +1,15 @@
-from elasticsearch_metrics.metrics import Metric
+from elasticsearch_metrics import metrics
 
 
-class DummyMetric(Metric):
+class DummyMetric(metrics.Metric):
     pass
 
 
-class DummyMetricWithExplicitTemplateName(Metric):
+class DummyMetricWithExplicitTemplateName(metrics.Metric):
     class Meta:
         template_name = "dummymetric"
 
 
-class DummyMetricWithExplicitTemplatePattern(Metric):
+class DummyMetricWithExplicitTemplatePattern(metrics.Metric):
     class Meta:
         template = "dummymetric-*"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,0 +1,12 @@
+import pytest
+from dateutil import tz
+
+from elasticsearch_metrics import metrics
+
+
+class TestDate:
+    @pytest.mark.parametrize("timezone", ["America/Chicago", "UTC"])
+    def test_respects_timezone_setting(self, settings, timezone):
+        settings.TIMEZONE = timezone
+        field = metrics.Date()
+        assert field._default_timezone == tz.gettz(timezone)

--- a/tests/test_management_commands/test_sync_metrics.py
+++ b/tests/test_management_commands/test_sync_metrics.py
@@ -1,7 +1,8 @@
 import pytest
 import mock
+
 from elasticsearch_metrics.management.commands.sync_metrics import Command
-from elasticsearch_metrics.metrics import Metric
+from elasticsearch_metrics import metrics
 from elasticsearch_metrics.registry import registry
 
 
@@ -25,7 +26,7 @@ def test_with_invalid_app(capsys, run_mgmt_command, mock_create_index_template):
 
 
 def test_with_app_label(run_mgmt_command, mock_create_index_template):
-    class DummyMetric2(Metric):
+    class DummyMetric2(metrics.Metric):
         class Meta:
             app_label = "dummyapp2"
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,11 +1,11 @@
 import pytest
 
-from elasticsearch_metrics.metrics import Metric
+from elasticsearch_metrics import metrics
 from elasticsearch_metrics.registry import registry
 from tests.dummyapp.metrics import DummyMetric
 
 
-class MetricWithAppLabel(Metric):
+class MetricWithAppLabel(metrics.Metric):
     class Meta:
         app_label = "dummyapp"
 
@@ -22,7 +22,7 @@ def test_metric_with_explicit_label_set_is_in_registry():
 def test_conflicting_metric():
     with pytest.raises(RuntimeError):
 
-        class DummyMetric(Metric):
+        class DummyMetric(metrics.Metric):
             class Meta:
                 app_label = "dummyapp"
 
@@ -43,7 +43,7 @@ def test_get_metric():
 
 
 def test_get_metrics():
-    class AnotherMetric(Metric):
+    class AnotherMetric(metrics.Metric):
         class Meta:
             app_label = "anotherapp"
 
@@ -58,7 +58,7 @@ def test_get_metrics():
 
 
 def test_get_metrics_excludes_abstract_metrics():
-    class AbstractMetric(Metric):
+    class AbstractMetric(metrics.Metric):
         class Meta:
             abstract = True
 
@@ -66,6 +66,6 @@ def test_get_metrics_excludes_abstract_metrics():
         class Meta:
             app_label = "anotherapp"
 
-    assert Metric not in registry.get_metrics()
+    assert metrics.Metric not in registry.get_metrics()
     assert AbstractMetric not in registry.get_metrics()
     assert ConcreteMetric in registry.get_metrics()


### PR DESCRIPTION
This adds a custom `Date` field which respects
`settings.TIMEZONE`.

This also exposes elasticsearch_dsl's fields from the `metrics`
module, so that all fields are imported from the same place:

```python
from elasticsearch_metrics import metrics

class MyMetric(metrics.Metric):
  my_keyword = metrics.Keyword()
  my_date = metrics.Date()
```

This approach was the same used in webargs, which uses
marshmallow fields under the hood but overrides a single
field. Discussion: https://github.com/sloria/webargs/issues/61#issuecomment-142166317

close #18