### PR TITLE
Speed up tests 2x

### DIFF
--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -126,9 +126,7 @@ class Metric(Document, BaseMetric):
 
     @classmethod
     def init(cls, index=None, using=None):
-        """
-        Create the index and populate the mappings in elasticsearch.
-        """
+        """Create the index and populate the mappings in elasticsearch."""
         return super(Metric, cls).init(index=index or cls.get_index_name(), using=using)
 
     def save(self, using=None, index=None, validate=True, **kwargs):


### PR DESCRIPTION
Refactor tests so that fewer tests rely on running elasticsearch

Before: 30 tests in ~2s
After: 30 tests in ~1s