### PR TITLE
Add factory_boy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 * *Backwards-incompatible*: By default, `Metric.search`, `Metric.get`, and `Metric.mget` will use
     the metric's template pattern as the default index (e.g.  `myapp_mymetric-*`).
 * Add `date` parameter to `Metric.save`.
+* Add optional factory_boy integration in `elasticsearch_metrics.factory`.
 
 ## 1.0.1 (2018-08-22)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ class PageView(MyBaseMetric):
         app_label = "myapp"
 ```
 
+## Optional factory_boy integration
+
+```python
+import factory
+from elasticsearch_metrics.factory import MetricFactory
+
+from ..myapp.metrics import MyMetric
+
+
+class MyMetricFactory(MetricFactory):
+    my_int = factory.Faker("pyint")
+
+    class Meta:
+        model = MyMetric
+
+
+def test_something():
+    metric = MyMetricFactory()  # index metric in ES
+    assert isinstance(metric.my_int, int)
+```
 
 ## Configuration
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ pytest==3.7.2
 pytest-django==3.4.2
 tox==3.2.1
 mock==2.0.0
+factory-boy==2.11.1
 
 # Pre-commit hooks
 pre-commit==1.10.5

--- a/elasticsearch_metrics/factory.py
+++ b/elasticsearch_metrics/factory.py
@@ -1,0 +1,20 @@
+"""factory_boy extension for elasticsearch_metrics."""
+from __future__ import absolute_import
+from factory import base
+
+
+class MetricFactory(base.Factory):
+    """Factory for Metric objects."""
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        return model_class(*args, **kwargs)
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        instance = model_class(*args, **kwargs)
+        instance.save()
+        return instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from elasticsearch_dsl import connections
@@ -25,6 +26,12 @@ def _es_marker(request, client):
         teardown_es()
     else:
         yield
+
+
+@pytest.fixture()
+def mock_save():
+    with mock.patch("elasticsearch_metrics.metrics.Document.save") as patch:
+        yield patch
 
 
 @pytest.fixture()

--- a/tests/dummyapp/metrics.py
+++ b/tests/dummyapp/metrics.py
@@ -2,7 +2,7 @@ from elasticsearch_metrics import metrics
 
 
 class DummyMetric(metrics.Metric):
-    pass
+    my_int = metrics.Integer()
 
 
 class DummyMetricWithExplicitTemplateName(metrics.Metric):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,24 @@
+import factory
+
+from elasticsearch_metrics import metrics
+from elasticsearch_metrics.factory import MetricFactory
+from tests.dummyapp.metrics import DummyMetric
+
+
+class DummyMetricFactory(MetricFactory):
+    my_int = factory.Faker("pyint")
+
+    class Meta:
+        model = DummyMetric
+
+
+def test_build():
+    metric = DummyMetricFactory.build()
+    assert isinstance(metric, metrics.Metric)
+    assert isinstance(metric.my_int, int)
+
+
+def test_save(mock_save):
+    metric = DummyMetricFactory()
+    assert isinstance(metric, metrics.Metric)
+    assert mock_save.call_count == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,12 +13,6 @@ from tests.dummyapp.metrics import (
 )
 
 
-@pytest.fixture()
-def mock_save():
-    with mock.patch("elasticsearch_metrics.metrics.Document.save") as patch:
-        yield patch
-
-
 class PreprintView(metrics.Metric):
     provider_id = metrics.Keyword(index=True)
     user_id = metrics.Keyword(index=True)


### PR DESCRIPTION
Adds a MetricFactory for creating factories for Metric
classes

Nothing fancy here. It's pretty much identical to the
MogoFactory: https://github.com/FactoryBoy/factory_boy/blob/master/factory/mogo.py

close #42