### PR TITLE
Add Metric.record and remove date param from Metric.save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.0 (unreleased)
+
+Features:
+
+* Add `Metric.record`.
+* Remove `date` parameter from `Metric.save`.
+
 ## 2.1.0 (2018-08-23)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ from myapp.metrics import PageView
 
 user = User.objects.latest()
 
-view = PageView(user_id=user.id)
 # By default we create an index for each day.
 # Therefore, this will persist the document
 # to an index called, e.g. "myapp_pageview-2020.02.04"
-view.save()
+PageView.record(user_id=user.id)
 ```
 
 Go forth and search!

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -126,11 +126,12 @@ class BaseMetric(object):
         return "{}-{}".format(cls._template_name, date_formatted)
 
     @classmethod
-    def record(cls, **kwargs):
+    def record(cls, timestamp=None, **kwargs):
         """Persist a metric in Elasticsearch.
+
+        :param datetime timestamp: Timestamp for the metric.
         """
-        timestamp = kwargs.get("timestamp", None) or timezone.now()
-        instance = cls(**kwargs)
+        instance = cls(timestamp=timestamp, **kwargs)
         index = cls.get_index_name(timestamp)
         instance.save(index=index)
         return instance

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -151,12 +151,22 @@ class TestGetIndexTemplate:
         assert doc["_source"]["enabled"] is True
 
 
-class TestSave:
-    def test_can_pass_date_to_save(self, mock_save):
+class TestRecord:
+    def test_calls_save(self, mock_save):
         timestamp = dt.datetime(2017, 8, 21)
-        p = PreprintView()
-        p.save(date=timestamp)
+        p = PreprintView.record(timestamp=timestamp, provider_id="abc12")
+        assert mock_save.call_count == 1
         assert p.timestamp == timestamp
+        assert p.provider_id == "abc12"
+
+    @mock.patch.object(timezone, "now")
+    def test_defaults_timestamp_to_now(self, mock_now, mock_save):
+        fake_now = dt.datetime(2016, 8, 21)
+        mock_now.return_value = fake_now
+
+        p = PreprintView.record(provider_id="abc12")
+        assert mock_save.call_count == 1
+        assert p.timestamp == fake_now
 
 
 class TestSignals:


### PR DESCRIPTION
In retrospect, adding the `date` param in #43  was a bad idea.
As @pattisdr pointed out in
https://github.com/sloria/django-elasticsearch-metrics/pull/5#discussion_r205828049,
a user could pass an index and a date that are in conflict.

With this change, Metric.save will choose the index based on the
value of the timestamp field.

This also adds a convenience method, Metric.record, that allows
a timestamp to be passed

```python
MyMetric.record(timestamp=..., my_field=...)
```

This improves the ergonomics because a user typically does not
need instances of a metric.