### PR TITLE
Add check_metrics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ python manage.py sync_metrics
 ```
 
 * `show_metrics`: Pretty-print a listing of all registered metrics.
+* `check_metrics`: Check if index templates have been created. Exits
+    with an error code if any metrics are out of sync.
 
 ```
 python manage.py show_metrics

--- a/elasticsearch_metrics/management/commands/check_metrics.py
+++ b/elasticsearch_metrics/management/commands/check_metrics.py
@@ -1,0 +1,58 @@
+import sys
+import logging
+from django.core.management.base import BaseCommand, CommandError
+
+from elasticsearch_metrics.registry import registry
+from elasticsearch_metrics.management.color import color_style
+
+
+class Command(BaseCommand):
+    help = "Check if registered metrics have a corresponding index templates in Elasticsearch."
+
+    def add_arguments(self, parser):
+        parser.add_argument("app_label", nargs="?", help="App label of an application.")
+        parser.add_argument(
+            "--connection",
+            action="store",
+            dest="connection",
+            default=None,
+            help='Elasticsearch connection to use. Defaults to the "default" connection.',
+        )
+
+    def handle(self, *args, **options):
+        # Avoid elasticsearch requests from getting logged
+        logging.getLogger("elasticsearch").setLevel(logging.CRITICAL)
+        style = color_style()
+        connection = options["connection"]
+        if options["app_label"]:
+            if options["app_label"] not in registry.all_metrics:
+                raise CommandError(
+                    "No metrics found for app '{}'".format(options["app_label"])
+                )
+            app_labels = [options["app_label"]]
+        else:
+            app_labels = registry.all_metrics.keys()
+
+        out_of_sync = False
+        self.stdout.write("Checking for missing index templates...")
+        for app_label in app_labels:
+            metrics = registry.get_metrics(app_label=app_label)
+            for metric in metrics:
+                metric_has_template = metric.check_index_template_exists(
+                    using=connection
+                )
+                if not out_of_sync and not metric_has_template:
+                    out_of_sync = True
+                if not metric_has_template:
+                    metric_name = metric.__name__
+                    template_name = metric._template_name
+                    self.stdout.write(
+                        "  {template_name} does not exist for {metric_name}".format(
+                            **locals()
+                        ),
+                        style.ERROR,
+                    )
+        if out_of_sync:
+            sys.exit(1)
+        else:
+            self.stdout.write("All metrics in sync.", style.SUCCESS)

--- a/tests/test_management_commands/test_check_metrics.py
+++ b/tests/test_management_commands/test_check_metrics.py
@@ -1,0 +1,27 @@
+import pytest
+import mock
+
+from elasticsearch_metrics.management.commands.check_metrics import Command
+from elasticsearch_metrics.registry import registry
+
+
+@pytest.fixture()
+def mock_check_index_template_exists():
+    with mock.patch(
+        "elasticsearch_metrics.metrics.Metric.check_index_template_exists"
+    ) as patch:
+        yield patch
+
+
+def test_exits_with_error_if_out_of_sync(
+    run_mgmt_command, mock_check_index_template_exists
+):
+    mock_check_index_template_exists.return_value = False
+    with pytest.raises(SystemExit):
+        run_mgmt_command(Command, ["check_metrics"])
+
+
+def test_exits_with_success(run_mgmt_command, mock_check_index_template_exists):
+    mock_check_index_template_exists.return_value = True
+    run_mgmt_command(Command, ["check_metrics"])
+    assert mock_check_index_template_exists.call_count == len(registry.get_metrics())

--- a/tests/test_management_commands/test_sync_metrics.py
+++ b/tests/test_management_commands/test_sync_metrics.py
@@ -8,8 +8,10 @@ from elasticsearch_metrics.registry import registry
 
 @pytest.fixture()
 def mock_create_index_template():
-    patch = mock.patch("elasticsearch_metrics.metrics.Metric.create_index_template")
-    return patch.start()
+    with mock.patch(
+        "elasticsearch_metrics.metrics.Metric.create_index_template"
+    ) as patch:
+        yield patch
 
 
 def test_without_args(run_mgmt_command, mock_create_index_template):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -239,3 +239,8 @@ class TestIntegration:
         document = PreprintView.get(id=doc.meta.id, index=PreprintView.get_index_name())
         # TODO flesh out this test more.  Try to query ES?
         assert document is not None
+
+    def test_check_index_template(self):
+        assert PreprintView.check_index_template_exists() is False
+        PreprintView.create_index_template()
+        assert PreprintView.check_index_template_exists() is True


### PR DESCRIPTION
Checks if index templates exist for all metrics. If
not, exits with an error.

![image](https://user-images.githubusercontent.com/2379650/44872874-a92ff680-ac64-11e8-903c-37a8cb765530.png)

Also fixes the way we use mock.patch objects.

closes #50