### PR TITLE
Make check_metrics fail if index template is out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Features:
 * *Backwards-incompatible*: Remove `Metric.check_index_template_exists`.
     Use `Metric.check_index_template` instead.
 
+Other changes:
+
+* *Backwards-incompatible*: Rename `Metric.create_index_template` to
+    `Metric.sync_index_template`.
+
 ## 3.2.0 (2018-08-30)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.0.0 (unreleased)
+
+Features:
+
+* Add `Metric.check_index_template`, which checks that the state of the
+    metric is in sync with the index template in Elasticsearch.
+* *Backwards-incompatible*: Remove `Metric.check_index_template_exists`.
+    Use `Metric.check_index_template` instead.
+
 ## 3.2.0 (2018-08-30)
 
 Features:

--- a/elasticsearch_metrics/exceptions.py
+++ b/elasticsearch_metrics/exceptions.py
@@ -1,0 +1,16 @@
+class ElasticsearchMetricsError(Exception):
+    """Base class from which all elasticsearch-metrics-related excpetions inherit."""
+
+
+class IndexTemplateNotFoundError(ElasticsearchMetricsError):
+    def __init__(self, message, client_error):
+        self.client_error = client_error
+        super(IndexTemplateNotFoundError, self).__init__(message)
+
+
+class IndexTemplateOutOfSyncError(ElasticsearchMetricsError):
+    def __init__(self, message, mappings_in_sync, patterns_in_sync, settings_in_sync):
+        self.mappings_in_sync = mappings_in_sync
+        self.patterns_in_sync = patterns_in_sync
+        self.settings_in_sync = settings_in_sync
+        super(IndexTemplateOutOfSyncError, self).__init__(message)

--- a/elasticsearch_metrics/management/commands/sync_metrics.py
+++ b/elasticsearch_metrics/management/commands/sync_metrics.py
@@ -48,6 +48,6 @@ class Command(BaseCommand):
                         **locals()
                     )
                 )
-                metric.create_index_template(using=connection)
+                metric.sync_index_template(using=connection)
 
         self.stdout.write("Synchronized metrics.", style.SUCCESS)

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -98,8 +98,8 @@ class BaseMetric(object):
         source = MetaField(enabled=False)
 
     @classmethod
-    def create_index_template(cls, using=None):
-        """Create an index template for this metric in Elasticsearch."""
+    def sync_index_template(cls, using=None):
+        """Sync the index template for this metric in Elasticsearch."""
         index_template = cls.get_index_template()
         index_template.document(cls)
         signals.pre_index_template_create.send(

--- a/tests/test_management_commands/test_check_metrics.py
+++ b/tests/test_management_commands/test_check_metrics.py
@@ -1,27 +1,28 @@
 import pytest
 import mock
 
+from elasticsearch_metrics import exceptions
 from elasticsearch_metrics.management.commands.check_metrics import Command
 from elasticsearch_metrics.registry import registry
 
 
 @pytest.fixture()
-def mock_check_index_template_exists():
+def mock_check_index_template():
     with mock.patch(
-        "elasticsearch_metrics.metrics.Metric.check_index_template_exists"
+        "elasticsearch_metrics.metrics.Metric.check_index_template"
     ) as patch:
         yield patch
 
 
-def test_exits_with_error_if_out_of_sync(
-    run_mgmt_command, mock_check_index_template_exists
-):
-    mock_check_index_template_exists.return_value = False
+def test_exits_with_error_if_out_of_sync(run_mgmt_command, mock_check_index_template):
+    mock_check_index_template.side_effect = exceptions.IndexTemplateNotFoundError(
+        "Index template does not exist", client_error=None
+    )
     with pytest.raises(SystemExit):
         run_mgmt_command(Command, ["check_metrics"])
 
 
-def test_exits_with_success(run_mgmt_command, mock_check_index_template_exists):
-    mock_check_index_template_exists.return_value = True
+def test_exits_with_success(run_mgmt_command, mock_check_index_template):
+    mock_check_index_template.return_value = True
     run_mgmt_command(Command, ["check_metrics"])
-    assert mock_check_index_template_exists.call_count == len(registry.get_metrics())
+    assert mock_check_index_template.call_count == len(registry.get_metrics())

--- a/tests/test_management_commands/test_sync_metrics.py
+++ b/tests/test_management_commands/test_sync_metrics.py
@@ -7,41 +7,41 @@ from elasticsearch_metrics.registry import registry
 
 
 @pytest.fixture()
-def mock_create_index_template():
+def mock_sync_index_template():
     with mock.patch(
-        "elasticsearch_metrics.metrics.Metric.create_index_template"
+        "elasticsearch_metrics.metrics.Metric.sync_index_template"
     ) as patch:
         yield patch
 
 
-def test_without_args(run_mgmt_command, mock_create_index_template):
+def test_without_args(run_mgmt_command, mock_sync_index_template):
     out, err = run_mgmt_command(Command, ["sync_metrics"])
-    assert mock_create_index_template.call_count == len(registry.get_metrics())
+    assert mock_sync_index_template.call_count == len(registry.get_metrics())
     assert "Synchronized metrics." in out
 
 
-def test_with_invalid_app(capsys, run_mgmt_command, mock_create_index_template):
+def test_with_invalid_app(capsys, run_mgmt_command, mock_sync_index_template):
     with pytest.raises(SystemExit):
         run_mgmt_command(Command, ["sync_metrics", "notanapp"])
     out, err = capsys.readouterr()
     assert "No metrics found for app 'notanapp'" in err
 
 
-def test_with_app_label(run_mgmt_command, mock_create_index_template):
+def test_with_app_label(run_mgmt_command, mock_sync_index_template):
     class DummyMetric2(metrics.Metric):
         class Meta:
             app_label = "dummyapp2"
 
     out, err = run_mgmt_command(Command, ["sync_metrics", "dummyapp2"])
-    assert mock_create_index_template.call_count == 1
+    assert mock_sync_index_template.call_count == 1
 
 
-def test_with_connection(run_mgmt_command, mock_create_index_template, settings):
+def test_with_connection(run_mgmt_command, mock_sync_index_template, settings):
     settings.ELASTICSEARCH_DSL = {
         "default": {"hosts": "localhost:9201"},
         "alternate": {"hosts": "localhost:9202"},
     }
     out, err = run_mgmt_command(Command, ["sync_metrics", "--connection", "alternate"])
-    call_kwargs = mock_create_index_template.call_args[1]
+    call_kwargs = mock_sync_index_template.call_args[1]
     assert call_kwargs["using"] == "alternate"
     assert "Using connection: 'alternate'" in out

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -180,7 +180,7 @@ class TestSignals:
         mock_post_index_template_listener = mock.Mock()
         signals.pre_index_template_create.connect(mock_pre_index_template_listener)
         signals.post_index_template_create.connect(mock_post_index_template_listener)
-        PreprintView.create_index_template()
+        PreprintView.sync_index_template()
         assert mock_pre_index_template_listener.call_count == 1
         assert mock_post_index_template_listener.call_count == 1
         pre_call_kwargs = mock_pre_index_template_listener.call_args[1]
@@ -247,7 +247,7 @@ class TestIntegration:
     def test_check_index_template(self):
         with pytest.raises(IndexTemplateNotFoundError):
             assert PreprintView.check_index_template() is False
-        PreprintView.create_index_template()
+        PreprintView.sync_index_template()
         assert PreprintView.check_index_template() is True
 
         # When settings change, template is out of sync
@@ -259,5 +259,5 @@ class TestIntegration:
         assert error.mappings_in_sync is True
         assert error.patterns_in_sync is True
 
-        PreprintView.create_index_template()
+        PreprintView.sync_index_template()
         assert PreprintView.check_index_template() is True


### PR DESCRIPTION
* Replace .check_index_template_exists with .check_index_template
* manage.py check_metrics will exit with an error if index template
  exists but is out of sync
* Rename `create_index_template` -> `sync_index_template`, which is a more accurate name.