### PR TITLE
Fix bug where different Metric classes were sharing index settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Features:
 * *Backwards-incompatible*: Remove `Metric.check_index_template_exists`.
     Use `Metric.check_index_template` instead.
 
+Bug fixes:
+
+* Fix bug where different `Metric` subclasses were sharing the same
+    index settings (incl. mappings).
+
 Other changes:
 
 * *Backwards-incompatible*: Rename `Metric.create_index_template` to

--- a/tests/dummyapp/metrics.py
+++ b/tests/dummyapp/metrics.py
@@ -6,6 +6,8 @@ class DummyMetric(metrics.Metric):
 
 
 class DummyMetricWithExplicitTemplateName(metrics.Metric):
+    my_keyword = metrics.Keyword()
+
     class Meta:
         template_name = "dummymetric"
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,6 +78,15 @@ class TestGetIndexTemplate:
         assert properties["user_id"] == {"type": "keyword", "index": True}
         assert properties["preprint_id"] == {"type": "keyword", "index": True}
 
+    # regression test
+    def test_mappings_are_not_shared(self):
+        template1 = DummyMetric.get_index_template()
+        template2 = DummyMetricWithExplicitTemplateName.get_index_template()
+        assert "my_int" in template1.to_dict()["mappings"]["doc"]["properties"]
+        assert "my_keyword" not in template1.to_dict()["mappings"]["doc"]["properties"]
+        assert "my_int" not in template2.to_dict()["mappings"]["doc"]["properties"]
+        assert "my_keyword" in template2.to_dict()["mappings"]["doc"]["properties"]
+
     def test_declaring_metric_with_no_app_label_or_template_name_errors(self):
         with pytest.raises(RuntimeError):
 


### PR DESCRIPTION
By default, `Document` subclasses use the default Index instance.
Instead, we want to create a new `Index` for every Metric
subclass.