### PR TITLE
Fix inheritance of Index

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -138,6 +138,9 @@ class TestGetIndexTemplate:
         class MyBaseMetric(metrics.Metric):
             user_id = metrics.Keyword(index=True)
 
+            class Index:
+                settings = {"number_of_shards": 2}
+
             class Meta:
                 abstract = True
 
@@ -147,6 +150,7 @@ class TestGetIndexTemplate:
 
         template = ConcreteMetric.get_index_template()
         assert template._template_name == "dummyapp_concretemetric"
+        assert template._index.to_dict()["settings"] == {"number_of_shards": 2}
 
     def test_source_may_be_enabled(self):
         class MyMetric(metrics.Metric):


### PR DESCRIPTION
Previously, inheriting `Index` from a parent class wasn't
working.

For example:

```python
class MyBaseMetric(Metric):
    class Index:
        settings = {"number_of_shards": 2}

class MyConcreteMetric(MyBaseMetric):
    pass
```

When indexing MyConcreteMetric, the indexes would have the
default 5 shards instead of 2.

This fix properly inherits the Index settings from parent classes.

https://openscience.atlassian.net/browse/PLAT-1137