### PR TITLE
Don't set _all on mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Signals are located in the `elasticsearch_metrics.signals` module.
 
 ## Caveats
 
-* `_source` and `_all` are disabled by default on metric indices in order to save
+* `_source` is disabled by default on metric indices in order to save
     disk space. For most metrics use cases, Users will not need to retrieve the source
     JSON documents. Be sure to understand the consequences of
     this: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#_disabling_source .

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -127,7 +127,6 @@ class BaseMetric(object):
     timestamp = Date(doc_values=True, required=True)
 
     class Meta:
-        all = MetaField(enabled=False)
         source = MetaField(enabled=False)
 
     @classmethod

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -69,7 +69,6 @@ class TestGetIndexTemplate:
     def test_get_index_template_creates_template_with_mapping(self):
         template = PreprintView.get_index_template()
         mappings = template.to_dict()["mappings"]
-        assert mappings["doc"]["_all"]["enabled"] is False
         assert mappings["doc"]["_source"]["enabled"] is False
         properties = mappings["doc"]["properties"]
         assert "timestamp" in properties
@@ -164,7 +163,6 @@ class TestGetIndexTemplate:
 
         template_dict = template.to_dict()
         doc = template_dict["mappings"]["doc"]
-        assert doc["_all"]["enabled"] is False
         assert doc["_source"]["enabled"] is True
 
 


### PR DESCRIPTION
_all is deprecated in Elasticsearch 6+
https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-all-field.html

This prevents a warning from being raised when creating new indices