### PR TITLE
Fix check_metrics erroring when number_of_shards is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.3 (2018-10-15)
+
+Bug fixes:
+
+* Fix `check_metrics` exiting with an error when "number_of_shards"  or
+    "number_of_replicas" is set on a metric.
+
 ## 4.0.2 (2018-10-08)
 
 Bug fixes:

--- a/elasticsearch_metrics/__init__.py
+++ b/elasticsearch_metrics/__init__.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from elasticsearch_dsl.connections import connections
 from django.utils.module_loading import autodiscover_modules
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"
 
 default_app_config = "elasticsearch_metrics.ElasticsearchMetricsConfig"
 

--- a/elasticsearch_metrics/metrics.py
+++ b/elasticsearch_metrics/metrics.py
@@ -169,9 +169,16 @@ class BaseMetric(object):
 
             mappings_in_sync = current_data["mappings"] == template_data["mappings"]
             if "settings" in current_data and "index" in current_data["settings"]:
-                settings_in_sync = current_data["settings"][
-                    "index"
-                ] == template_data.get("settings", {})
+                current_settings = current_data["settings"]["index"]
+                template_settings = template_data.get("settings", {})
+                # ES automatically casts number_of_shards and number_of_replicas to a string
+                # so we need to cast before we compare
+                # TODO: Are there other settings that need to be handled?
+                number_settings = {"number_of_shards", "number_of_replicas"}
+                for setting in number_settings:
+                    if setting in template_settings:
+                        template_settings[setting] = str(template_settings[setting])
+                settings_in_sync = current_settings == template_settings
             else:
                 settings_in_sync = True
             patterns_in_sync = (

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -262,7 +262,9 @@ class TestIntegration:
         assert PreprintView.check_index_template() is True
 
         # When settings change, template is out of sync
-        PreprintView._index.settings(**{"refresh_interval": "1s"})
+        PreprintView._index.settings(
+            **{"refresh_interval": "1s", "number_of_shards": 1, "number_of_replicas": 2}
+        )
         with pytest.raises(IndexTemplateOutOfSyncError) as excinfo:
             assert PreprintView.check_index_template() is False
         error = excinfo.value


### PR DESCRIPTION
ES casts some settings as a string, so we need to do
the same casting before we compare the current settings
with the old settings